### PR TITLE
Updating links in components to go to their specific github page

### DIFF
--- a/valence-ui-components/valence-ui-alerts.rst
+++ b/valence-ui-components/valence-ui-alerts.rst
@@ -2,7 +2,7 @@
 Alerts
 ##################
 
-The `vui-alerts <https://www.npmjs.com/browse/keyword/vui>`_ library contains mixins and CSS that can be used to apply alert styles to a containing element. In most cases you'll want to apply this alert style to a simple container for a message; however, you don’t have to limit the container’s contents to just text (for example, the container can include images, buttons, other HTML, and so on).
+The `vui-alerts <https://github.com/Brightspace/valence-ui-alerts>`_ library contains mixins and CSS that can be used to apply alert styles to a containing element. In most cases you'll want to apply this alert style to a simple container for a message; however, you don’t have to limit the container’s contents to just text (for example, the container can include images, buttons, other HTML, and so on).
 
 .. role:: example
 

--- a/valence-ui-components/valence-ui-breadcrumbs.rst
+++ b/valence-ui-components/valence-ui-breadcrumbs.rst
@@ -1,11 +1,11 @@
 ##################
-Breadcrumbs 
+Breadcrumbs
 ##################
 
-The `vui-breadcrumbs <https://www.npmjs.com/browse/keyword/vui>`_ library contains a series of Less mixins and CSS that you can use to style breadcrumbs.
+The `vui-breadcrumbs <https://github.com/Brightspace/valence-ui-breadcrumbs>`_ library contains a series of Less mixins and CSS that you can use to style breadcrumbs.
 
 .. role:: example
-  
+
 :example:`Example`
 
 .. raw:: html
@@ -19,13 +19,13 @@ The `vui-breadcrumbs <https://www.npmjs.com/browse/keyword/vui>`_ library contai
   </div>
 
 *******************
-Styling with Less 
+Styling with Less
 *******************
 If you're familiar with `Less <http://lesscss.org/>`_, style your breadcrumbs with our Less mixins. First, you'll need to import the breadcrumbs library into your Less file:
 
 
 .. code-block:: console
-  
+
   @import '<npm module path>/vui-breadcrumbs/breadcrumbs'
 
 You can apply breadcrumb styles by implementing the ``#vui.Breadcrumbs()`` mixin on your breadcrumb container.
@@ -33,7 +33,7 @@ You can apply breadcrumb styles by implementing the ``#vui.Breadcrumbs()`` mixin
 Less:
 
 .. code-block:: css
-    
+
     ol.breadcrumbs {
       #vui.Breadcrumbs();
     }
@@ -41,7 +41,7 @@ Less:
 HTML:
 
 .. code-block:: html
-  
+
   <ol class="breadcrumbs">
     <li><a>Crumb 1</a></li>
     <li><a>Crumb 2</a></li>

--- a/valence-ui-components/valence-ui-button.rst
+++ b/valence-ui-components/valence-ui-button.rst
@@ -2,28 +2,28 @@
 Button
 ##################
 
-The `vui-button <https://www.npmjs.com/browse/keyword/vui>`_ library contains Less mixins and CSS that you can use to style buttons. 
+The `vui-button <https://github.com/Brightspace/valence-ui-button>`_ library contains Less mixins and CSS that you can use to style buttons.
 
 .. role:: example
-	
+
 :example:`Example`
 
 .. raw:: html
-  
+
   <div class="vuiexamplebox vui-typography">
     <button class="vui-button vui-primary">Button 1</button>
     <button class="vui-button">Button 2</button>
     <input class="vui-button" type="button" value="Button 3" />
-    <button class="vui-button" disabled="disabled">Button 4</button> 
+    <button class="vui-button" disabled="disabled">Button 4</button>
   </div>
 
 *******************
-Styling with Less 
+Styling with Less
 *******************
 If you're familiar with `Less <http://lesscss.org/>`_, style your buttons with our Less mixins.  First, you'll need to import the button library into your Less file:
 
 .. code-block:: console
-	
+
 	@import '<npm module path>/vui-button/button'
 
 To apply button styling to an element, call the ``#vui.Button()`` mixin from within your CSS selector. You can also make an element a primary button by calling the ``#vui.Button.primary()`` mixin.
@@ -45,7 +45,7 @@ HTML:
 
 	<button class="primary">Button 1</button>
 	<button>Button 2</button>
-	<input type="button" value="Button 3" /> 
+	<input type="button" value="Button 3" />
 	<button disabled="disabled">Button 4</button>
 
 *******************
@@ -58,7 +58,7 @@ your application's CSS. Then apply the ``.vui-button`` and ``.vui-button-primary
 
   <button class="vui-button vui-primary">Button 1</button>
   <button class="vui-button">Button 2</button>
-  <input class="vui-button" type="button" value="Button 3" /> 
+  <input class="vui-button" type="button" value="Button 3" />
   <button class="vui-button" disabled="disabled">Button 4</button>
 
 
@@ -68,7 +68,7 @@ Buttons with Icons
 To include an icon inside a button, add a ``<span>`` element inside the button and apply the appropriate Less mixin or CSS class for the icon.  For more information, see :doc:`Icons <../valence-ui-components/valence-ui-icons>`.
 
 .. role:: example
-	
+
 :example:`Example`
 
 .. raw:: html
@@ -82,7 +82,7 @@ To include an icon inside a button, add a ``<span>`` element inside the button a
         <span class="vui-icon-edit"></span> Edit
       </button>
     </div>
-    <div>        
+    <div>
       <button class="vui-button">
         <span class="vui-icon-bookmark"></span>
         <span class="vui-offscreen">Bookmark</span>
@@ -107,13 +107,13 @@ Less:
   {
     #vui.Icon();
   }
-  
+
   .icon-bookmark {
-    #vui.Icon.actionBookmark();  
+    #vui.Icon.actionBookmark();
   }
 
   .icon-edit {
-    #vui.Icon.actionEdit();  
+    #vui.Icon.actionEdit();
   }
 
 

--- a/valence-ui-components/valence-ui-focus.rst
+++ b/valence-ui-components/valence-ui-focus.rst
@@ -2,12 +2,12 @@
 Focus
 ##################
 
-The `vui-focus <https://www.npmjs.com/browse/keyword/vui>`_ library provides uncompiled Less and compiled CSS that can be used to apply an outline style to elements when they receive focus. This accessibility feature helps identify to the user which element currently has focus.
+The `vui-focus <https://github.com/Brightspace/valence-ui-focus>`_ library provides uncompiled Less and compiled CSS that can be used to apply an outline style to elements when they receive focus. This accessibility feature helps identify to the user which element currently has focus.
 
 In most cases, you'll want to use this library on elements that do not already have a visible or obvious focus indicator, which is usually links, checkboxes and radio buttons.
 
 *******************
-Styling with Less 
+Styling with Less
 *******************
 If you're familiar with `Less <http://lesscss.org/>`_, use our Less mixins to apply focus styling to elements. First, you'll need to import the focus library into your Less file:
 
@@ -22,9 +22,9 @@ Call the ``#vui.focusOutline()`` mixin from your CSS selector, usually with the 
   a:focus {
     #vui.focusOutline();
   }
-  
+
 *******************
-Styling with CSS 
+Styling with CSS
 *******************
 If you'd prefer to use plain CSS instead of Less, bundle the **focus.css** file with your application's CSS. Then apply the ``.vui-outline`` class to any element in your HTML. When that element receives focus, the outline style is applied automatically.
 

--- a/valence-ui-components/valence-ui-form.rst
+++ b/valence-ui-components/valence-ui-form.rst
@@ -4,19 +4,19 @@
    :depth: 1
 
 
-Forms are typically comprised of fields, labels, and inputs. 
+Forms are typically comprised of fields, labels, and inputs.
 
 *********************
 Text Inputs
 *********************
-The `vui-input <https://www.npmjs.com/browse/keyword/vui>`_ library contains Less mixins and CSS that can be used to style inputs.
+The `vui-input <https://github.com/Brightspace/valence-ui-input>`_ library contains Less mixins and CSS that can be used to style inputs.
 
 .. role:: example
-    
+
 :example:`Example`
 
 .. raw:: html
-    
+
   <div class="vuiexamplebox vui-typography">
   <div class="vui-field-row">
     <input style="width:200px;" class="vui-input" type="text" value="Some text" />
@@ -48,7 +48,7 @@ The `vui-input <https://www.npmjs.com/browse/keyword/vui>`_ library contains Les
   </div>
   </div>
 
-Styling with Less 
+Styling with Less
 ==================
 To apply styling to text inputs with Less, first import the following libraries into your Less file:
 
@@ -65,8 +65,8 @@ Less:
 
 .. code-block:: css
 
-  input, 
-  input[type="text"], 
+  input,
+  input[type="text"],
   input[type="password"],
   input[type="email"],
   input[type="url"]
@@ -111,7 +111,7 @@ HTML:
     </select>
   </div>
 
-Styling with CSS 
+Styling with CSS
 ==================
 To style text inputs with CSS, apply the ``.vui-input`` class to the  ``<input>``, ``<textarea>`` and ``<select>`` elements.
 
@@ -148,7 +148,7 @@ To style text inputs with CSS, apply the ``.vui-input`` class to the  ``<input>`
 Fields and Labels
 *********************
 
-The `vui-field <https://www.npmjs.com/browse/keyword/vui>`_ library contain a series of Less mixins and CSS that can be used to style fields and labels.
+The `vui-field <https://github.com/Brightspace/valence-ui-field>`_ library contain a series of Less mixins and CSS that can be used to style fields and labels.
 
 .. admonition::  Accessibility
 
@@ -157,11 +157,11 @@ The `vui-field <https://www.npmjs.com/browse/keyword/vui>`_ library contain a se
   For additional information, see `Techniques for WCAG 2.0: Using label elements to associate text labels with form controls <http://www.w3.org/TR/WCAG-TECHS/H44.html>`_.
 
 .. role:: example
-    
+
 :example:`Example`
 
 .. raw:: html
-    
+
   <div class="vuiexamplebox vui-typography">
     <div class="vui-field-row">
       <label class="vui-label">
@@ -177,17 +177,17 @@ The `vui-field <https://www.npmjs.com/browse/keyword/vui>`_ library contain a se
     </div>
   </div>
 
-Styling with Less 
+Styling with Less
 ==================
 If you're familiar with `Less <http://lesscss.org/>`_, style your fields and labels with our Less mixins.  First, you'll need to import the following  libraries into your Less file:
 
 .. code-block:: console
-    
+
   @import '<npm module path>/vui-field/label';
   @import '<npm module path>/vui-field/field';
 
 
-Form fields (checkboxes, text inputs, etc.) can be grouped by calling the 
+Form fields (checkboxes, text inputs, etc.) can be grouped by calling the
 ``#vui.FieldRow()`` mixin, which gives the field a standard bottom margin. This mixin would typically be applied to a ``<div>`` (or other element) used to surround each field.
 
 To style field labels, call the ``#vui.Label()`` mixin from within the ``label`` selector.
@@ -208,7 +208,7 @@ Less:
     #vui.Input();
   }
 
-HTML: 
+HTML:
 
 .. code-block:: html
 
@@ -225,7 +225,7 @@ HTML:
     </label>
   </div>
 
-Styling with CSS 
+Styling with CSS
 ==================
 If you'd prefer to use CSS instead of Less, you can group and stack form fields vertically by applying the ``.vui-field-row`` class. Then apply the ``.vui-label`` class to a ``<label>`` element.
 
@@ -249,42 +249,42 @@ The ``.vui-field-row`` class gives the field a standard bottom margin.
 ****************
 Required Fields
 ****************
-The `vui-field <https://www.npmjs.com/browse/keyword/vui>`_ library contain Less mixins and CSS that can be used to indicate whether a field is required.  A required field is distinguished with a red asterisk (*).
+The `vui-field <https://github.com/Brightspace/valence-ui-field>`_ library contain Less mixins and CSS that can be used to indicate whether a field is required.  A required field is distinguished with a red asterisk (*).
 
 .. role:: example
-    
+
 :example:`Example`
 
 .. raw:: html
-    
+
   <div class="vuiexamplebox vui-typography">
     <div class="vui-field-row">
       <label class="vui-label">
         <span class="vui-required">Name</span>
           <input class="vui-input" type="text" placeholder="Enter your name" aria-required="true" required  />
-      </label>        
+      </label>
     </div>
   </div>
 
 .. admonition::  Accessibility
 
-  It's important to note that a required field is indicated with `just a visual flag`. To ensure you meet accessibility requirements, mark up the corresponding input with the `HTML5 "required" attribute <http://www.w3.org/html/wg/drafts/html/master/forms.html#the-required-attribute>`_ and the `"aria-required" attribute <http://www.w3.org/TR/wai-aria/states_and_properties#aria-required>`_. For more information, see 
+  It's important to note that a required field is indicated with `just a visual flag`. To ensure you meet accessibility requirements, mark up the corresponding input with the `HTML5 "required" attribute <http://www.w3.org/html/wg/drafts/html/master/forms.html#the-required-attribute>`_ and the `"aria-required" attribute <http://www.w3.org/TR/wai-aria/states_and_properties#aria-required>`_. For more information, see
   `MDN: Using the aria-required attribute <https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-required_attribute>`_.
 
 
-Styling with Less 
+Styling with Less
 ==================
 A field can be visually flagged as required by applying the ``#vui.Label.required()`` mixin to a selector.
 
 Less:
 
 .. code-block:: css
-    
+
   @import '<npm module path>/vui-field/label';
 
   .required {
     #vui.Label.required();
-  }   
+  }
 
 HTML:
 
@@ -298,7 +298,7 @@ HTML:
   </div>
 
 
-Styling with CSS 
+Styling with CSS
 ==================
 To visually flag a field as required with CSS, apply the ``.vui-required`` class to the element containing the label text.
 
@@ -308,7 +308,7 @@ To visually flag a field as required with CSS, apply the ``.vui-required`` class
     <label class="vui-label">
       <span class="vui-required">Name</span>
       <input class="vui-input" type="text" placeholder="Enter your name" aria-required="true" required />
-    </label>        
+    </label>
   </div>
 
 .. _vui-fieldsets:
@@ -324,7 +324,7 @@ When you have more than one related form element, group them together using the 
 
 
 .. role:: example
-    
+
 :example:`Example`
 
 .. raw:: html
@@ -347,7 +347,7 @@ When you have more than one related form element, group them together using the 
     </fieldset>
   </div>
 
-Styling with Less 
+Styling with Less
 ==================
 Apply the ``#vui.FieldRow()`` mixin to the ``<fieldset>`` element and apply the ``#vui.Label()`` mixin to the ``<legend>`` element.
 
@@ -385,7 +385,7 @@ HTML:
     </label>
   </fieldset>
 
-Styling with CSS 
+Styling with CSS
 ==================
 Apply the ``.vui-field-row`` class to the ``<fieldset>`` element and apply the ``.vui-label`` class to the ``<legend>`` element.
 

--- a/valence-ui-components/valence-ui-icons.rst
+++ b/valence-ui-components/valence-ui-icons.rst
@@ -2,14 +2,14 @@
 Icons
 ##################
 
-The `vui-icons <https://www.npmjs.com/browse/keyword/vui>`_ library provides Less mixins and CSS classes for adding icons to your app. All icons are available in the "small" size of 16x16. The file icons are available in three different sizes: 16x16 (small), 24x24 (large), and 50x50 (xlarge). 
+The `vui-icons <https://github.com/Brightspace/valence-ui-icons>`_ library provides Less mixins and CSS classes for adding icons to your app. All icons are available in the "small" size of 16x16. The file icons are available in three different sizes: 16x16 (small), 24x24 (large), and 50x50 (xlarge).
 
 .. role:: example
-    
+
 :example:`Example`
 
 .. raw:: html
-    
+
   <div class="vuiexamplebox">
     <div>
       <span class="vui-icon-file-pdf"></span>
@@ -19,7 +19,7 @@ The `vui-icons <https://www.npmjs.com/browse/keyword/vui>`_ library provides Les
   </div>
 
 *******************
-Styling with Less 
+Styling with Less
 *******************
 If you're familiar with `Less <http://lesscss.org/>`_, add icons to your app with our Less mixins.  First, you'll need to import the following library into your Less file:
 
@@ -27,8 +27,8 @@ If you're familiar with `Less <http://lesscss.org/>`_, add icons to your app wit
 
   @import '<npm module path>/vui-icons/icons';
 
-To apply the general styling for icons, call the ``#vui.Icon()`` mixin from within the icon's CSS selector.  Then call the appropriate mixin for the specified icon. For example, the small PDF file icon is generated with the ``vui.Icon.filePdf()`` mixin.  
-    
+To apply the general styling for icons, call the ``#vui.Icon()`` mixin from within the icon's CSS selector.  Then call the appropriate mixin for the specified icon. For example, the small PDF file icon is generated with the ``vui.Icon.filePdf()`` mixin.
+
 Less:
 
 .. code-block:: css
@@ -36,7 +36,7 @@ Less:
   [class^=icon] {
     #vui.Icon();
   }
-  
+
   .icon-filePdf {
     #vui.Icon.filePdf();
   }
@@ -56,24 +56,24 @@ HTML:
   <span class="icon-filePdf"></span>
   <span class="icon-filePdfLarge"></span>
   <span class="icon-filePdfXLarge"></span>
-   
+
 
 *******************
-Styling with CSS 
+Styling with CSS
 *******************
-If you’d prefer to use plain CSS instead of Less, bundle the **icons.css** file with your application’s CSS. Then apply the specified CSS class name on a ``<span>`` element. 
+If you’d prefer to use plain CSS instead of Less, bundle the **icons.css** file with your application’s CSS. Then apply the specified CSS class name on a ``<span>`` element.
 
 .. code-block:: html
-  
+
   <span class="vui-icon-file-pdf"></span>
   <span class="vui-icon-file-pdf-large"></span>
   <span class="vui-icon-file-pdf-xlarge"></span>
-   
+
 
 *********************
 Available Icons
 *********************
-In the Less mixins, the icons are named with the following conventions: 
+In the Less mixins, the icons are named with the following conventions:
 
 .. raw:: html
 
@@ -83,7 +83,7 @@ In the Less mixins, the icons are named with the following conventions:
     <li>property<i>PropertyName</i> (examples: <tt>propertyDateRestricted</tt>, <tt>propertyLocked</tt>)</li>
   </ul>
 
-In the CSS, the icons are named with the following conventions: 
+In the CSS, the icons are named with the following conventions:
 
 .. raw:: html
 

--- a/valence-ui-components/valence-ui-jquery-accordion.rst
+++ b/valence-ui-components/valence-ui-jquery-accordion.rst
@@ -2,7 +2,7 @@
 Accordion
 ##################
 
-The `jquery-vui-accordion <https://www.npmjs.com/browse/keyword/vui>`_ library provides a jQuery-based widget that displays a panel that when clicked, expands or collapses the associated content.
+The `jquery-vui-accordion <https://github.com/Brightspace/jquery-valence-ui-accordion>`_ library provides a jQuery-based widget that displays a panel that when clicked, expands or collapses the associated content.
 
 .. raw:: html
 

--- a/valence-ui-components/valence-ui-jquery-change-tracking.rst
+++ b/valence-ui-components/valence-ui-jquery-change-tracking.rst
@@ -2,10 +2,10 @@
 Change Tracking
 ##################
 
-The `jquery-vui-change-tracking <https://www.npmjs.com/browse/keyword/vui>`_ library provides jQuery-based widgets, events, Less mixins, and CSS that can be used to visually indicate unsaved changes to form inputs.  When a user changes the input value for a field, the field is highlighted with a background color.
+The `jquery-vui-change-tracking <https://github.com/Brightspace/jquery-valence-ui-change-tracking>`_ library provides jQuery-based widgets, events, Less mixins, and CSS that can be used to visually indicate unsaved changes to form inputs.  When a user changes the input value for a field, the field is highlighted with a background color.
 
 .. role:: example
-    
+
 :example:`Example`
 
 .. raw:: html
@@ -56,9 +56,9 @@ Here's the HTML:
       ...
     </fieldset>
   </form>
-    
+
   ...
-    
+
   <script src="<npm module path>/jquery-vui-change-tracking/changeTracking.js"></script>
   <script src="<npm module path>/jquery-vui-change-tracking/changeTracker.js"></script>
   <script>
@@ -68,22 +68,22 @@ Here's the HTML:
     });
   </script>
 
-To enable change tracking, add the ``data-track-changes="true"`` attribute to the containing element (for example, on the ``<form>`` element). 
+To enable change tracking, add the ``data-track-changes="true"`` attribute to the containing element (for example, on the ``<form>`` element).
 
 To initialize the change tracking widgets:
 
-- Call the ``vui_changeTracker()`` function on the elements that contain the input fields (for example, on the ``<fieldset>`` or field row).  
+- Call the ``vui_changeTracker()`` function on the elements that contain the input fields (for example, on the ``<fieldset>`` or field row).
 
 	This function applies the highlighting style to the changed elements. Typically, your inputs will be contained in a field row  (see :ref:`Fields and Labels <vui-fieldlabels>` ), so the highlighting will be applied to the whole row; however, if you want to highlight individual fields, call ``vui_changeTracker()``  for those elements.
 
-- Call the ``vui_changeTracking()`` function on the inputs that you want to track. 
-	
-	This function triggers events when the specified elements have changed. 
+- Call the ``vui_changeTracking()`` function on the inputs that you want to track.
+
+	This function triggers events when the specified elements have changed.
 
 In the example above, changes are tracked for inputs that specify the ``.input-tracking`` class.  The changes are highlighted on the containing element that has the ``.tracker`` class.
 
 *********************
-Styling with Less 
+Styling with Less
 *********************
 If you're familiar with `Less <http://lesscss.org/>`_, you can apply the change tracking style with the ``#vui.changed()`` mixin. First, you'll need to import the following library into your Less file:
 
@@ -91,7 +91,7 @@ If you're familiar with `Less <http://lesscss.org/>`_, you can apply the change 
 
   @import '<npm module path>/jquery-vui-change-tracking/changeTracking';
 
-Then call the ``#vui.changed()`` mixin within the ``.vui-changed`` class selector: 
+Then call the ``#vui.changed()`` mixin within the ``.vui-changed`` class selector:
 
 .. code-block:: css
 
@@ -100,7 +100,7 @@ Then call the ``#vui.changed()`` mixin within the ``.vui-changed`` class selecto
   }
 
 *******************
-Styling with CSS 
+Styling with CSS
 *******************
 If you'd prefer to use plain CSS instead of Less, bundle the **changeTracking.css** file with your application's CSS. The ``.vui-changed`` style will be used by the change tracking widgets to apply the highlighting style to the changed elements.
 
@@ -111,7 +111,7 @@ Resetting the state
 The change-tracking state can be reset for one or more elements by triggering the ``vui-reset`` event on an ancestor container. For instance, this may be called after saving changes.
 
 .. role:: example
-    
+
 :example:`Example`
 
 .. raw:: html
@@ -121,8 +121,8 @@ The change-tracking state can be reset for one or more elements by triggering th
       <div class="tracker vui-field-row">
         <label class="vui-label">
           Reset Example
-          <input class="input-tracking vui-input" type="text">    
-        </label> 
+          <input class="input-tracking vui-input" type="text">
+        </label>
       </div>
     </div>
     <button class="vui-button" onclick="$( '#tracking_container' ).trigger( 'vui-reset' );" value="Reset">Reset</button>
@@ -133,7 +133,7 @@ HTML:
 .. code-block:: html
 
   <div id="tracking_container" data-track-changes="true">
-    ... 
+    ...
   </div>
   <script>
     $( '#tracking_container' ).trigger( 'vui-reset' );

--- a/valence-ui-components/valence-ui-jquery-collapsible-section.rst
+++ b/valence-ui-components/valence-ui-jquery-collapsible-section.rst
@@ -2,7 +2,7 @@
 Collapsible Section
 ####################
 
-The `jquery-vui-collapsible-section <https://www.npmjs.com/browse/keyword/vui>`_ library provides a jQuery-based widget representing a collapsible section of content.
+The `jquery-vui-collapsible-section <https://github.com/Brightspace/jquery-valence-ui-collapsible-section>`_ library provides a jQuery-based widget representing a collapsible section of content.
 
 .. role:: example
 

--- a/valence-ui-components/valence-ui-link.rst
+++ b/valence-ui-components/valence-ui-link.rst
@@ -2,7 +2,7 @@
 Link
 ####################
 
-The `vui-link <https://www.npmjs.com/browse/keyword/vui>`_ library contains Less mixins and CSS that you can use to style links. 
+The `vui-link <https://github.com/Brightspace/valence-ui-link>`_ library contains Less mixins and CSS that you can use to style links.
 
 .. role:: example
 
@@ -16,7 +16,7 @@ The `vui-link <https://www.npmjs.com/browse/keyword/vui>`_ library contains Less
   </div>
 
 *******************
-Styling with Less 
+Styling with Less
 *******************
 If you're familiar with `Less <http://lesscss.org/>`_, style your links with our Less mixins. First, you'll need to import the link library into your Less file:
 
@@ -40,9 +40,9 @@ You can also override the link color and focus colors:
 
 .. code-block:: css
 
-  #vui.Link( 
-    @color: #ff0000, 
-    @color-focus: #0000ff 
+  #vui.Link(
+    @color: #ff0000,
+    @color-focus: #0000ff
   );
 
 These colors are also exposed as variables, which can be referenced in your Less:

--- a/valence-ui-components/valence-ui-list.rst
+++ b/valence-ui-components/valence-ui-list.rst
@@ -2,14 +2,14 @@
 List
 ##################
 
-The `vui-list <https://www.npmjs.com/browse/keyword/vui>`_ library contains Less mixins and CSS that you can use to style lists. 
+The `vui-list <https://github.com/Brightspace/valence-ui-list>`_ library contains Less mixins and CSS that you can use to style lists.
 
 .. role:: example
-	
+
 :example:`Examples`
 
 .. raw:: html
-  
+
   <p><strong>Default list with separators and padding</strong></p>
   <div class="vuiexamplebox vui-typography">
     <div class="vui-docs-example">
@@ -33,19 +33,19 @@ The `vui-list <https://www.npmjs.com/browse/keyword/vui>`_ library contains Less
   </div>
 
 *********************
-Styling with Less 
+Styling with Less
 *********************
 If you're familiar with `Less <http://lesscss.org/>`_, you can style lists with our Less mixins.  First, you'll need to import the following library into your Less file:
 
 .. code-block:: console
-  
+
   @import '<npm module path>/vui-list/list';
 
 
 To apply list styling, call the ``#vui.List()`` mixin within your list's CSS selector:
 
 .. code-block:: css
-  
+
   ul {
     #vui.List();
   }
@@ -80,7 +80,7 @@ and we expose different mixins for each state:
 To apply states to list items, call the ``#vui.ListItem.selected()`` and ``#vui.ListItem.active()`` sub-mixins. For items that are both selected and active, call ``#vui.ListItem.selected.active()``.
 
   .. role:: example
-  
+
 :example:`Example`
 
 .. raw:: html
@@ -98,7 +98,7 @@ To apply states to list items, call the ``#vui.ListItem.selected()`` and ``#vui.
 
 
 .. code-block:: css
-  
+
   @import '<npm module path>/vui-list/list-item';
 
   li:hover, li:focus {
@@ -117,7 +117,7 @@ In this example, we applied the *active* state to any list items that receive fo
 *********************
 Styling with CSS
 *********************
-If you'd prefer to use CSS to style lists, bundle the provided **list.css** file with your application's CSS. 
+If you'd prefer to use CSS to style lists, bundle the provided **list.css** file with your application's CSS.
 
 
 Apply the ``.vui-list`` class to your list elements:
@@ -133,7 +133,7 @@ Similar to the Less mixin, you can disable the separators between list items
 by adding the ``.vui-no-separator`` class:
 
 .. code-block:: css
-	
+
   <ul class="vui-list vui-no-separator"></ul>
 
 To reduce padding inside the items, apply the ``.vui-compact`` class:

--- a/valence-ui-components/valence-ui-offscreen.rst
+++ b/valence-ui-components/valence-ui-offscreen.rst
@@ -2,12 +2,12 @@
 Off-screen
 ##################
 
-The `vui-offscreen <https://www.npmjs.com/browse/keyword/vui>`_ library provides a Less mixin and CSS for positioning elements off the screen. 
+The `vui-offscreen <https://github.com/Brightspace/valence-ui-offscreen>`_ library provides a Less mixin and CSS for positioning elements off the screen.
 
 Off-screen elements are valuable from an accessibility perspective when you want to have elements that are hidden to sighted users while being recognizable for screen reader users. However, you should make sure to apply off-screen to the correct elements. If you hide elements that receive focus, this might confuse sighted users because they will not be able to see which element has focus. For more information, read `WebAIM's article on Invisible Content <http://webaim.org/techniques/css/invisiblecontent/>`_.
 
 *********************
-Styling with Less 
+Styling with Less
 *********************
 If you're familiar with `Less <http://lesscss.org/>`_, you can add off-screen styles with our Less mixins.  First, you'll need to import the following library into your Less file:
 
@@ -17,7 +17,7 @@ If you're familiar with `Less <http://lesscss.org/>`_, you can add off-screen st
 
 To position an element offscreen, call the ``#vui.offscreen()`` mixin from within your selector.
 
-Less: 
+Less:
 
 .. code-block:: css
 
@@ -25,7 +25,7 @@ Less:
     #vui.offscreen();
   }
 
-HTML: 
+HTML:
 
 .. code-block:: html
 
@@ -35,7 +35,7 @@ HTML:
 
 
 *********************
-Styling with CSS 
+Styling with CSS
 *********************
 If you'd prefer to use CSS to style lists, bundle the provided **offscreen.css** file with your application's CSS. Then apply the ``.vui-offscreen`` class to your element.
 

--- a/valence-ui-components/valence-ui-typography.rst
+++ b/valence-ui-components/valence-ui-typography.rst
@@ -3,38 +3,38 @@
 .. contents::
    :depth: 1
 
-The `vui-typography <https://www.npmjs.com/browse/keyword/vui>`_ library contains `Less <http://lesscss.org/>`_ mixins and CSS that can be used to produce basic typography styles.
+The `vui-typography <https://github.com/Brightspace/valence-ui-typography>`_ library contains `Less <http://lesscss.org/>`_ mixins and CSS that can be used to produce basic typography styles.
 
 *********************
 Default text
 *********************
-You can apply default text styling to a block-level element (for example, ``<body>``, ``<p>``, ``<div>``, and so on) by using Less or plain CSS. 
+You can apply default text styling to a block-level element (for example, ``<body>``, ``<p>``, ``<div>``, and so on) by using Less or plain CSS.
 
 .. role:: example
-    
+
 :example:`Example`
 
 .. raw:: html
 
-  <div class="vuiexamplebox">    
+  <div class="vuiexamplebox">
     <p class="vui-typography">
       Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
     </p>
   </div>
 
-Styling with Less 
+Styling with Less
 ==================
 To apply default text styling in Less, call the ``#vui.Typography()`` mixin from within your selector.
 
 .. code-block:: css
-	
+
   @import '<npm module path>/vui-typography/typography';
 
   body {
     #vui.Typography();
   }
 
-Styling with CSS 
+Styling with CSS
 ==================
 If you'd prefer to use CSS, bundle the **typography.css** file with your application's CSS. Then apply the ``.vui-typography`` class to the block-level element.
 
@@ -50,12 +50,12 @@ Headings
 Four incremental heading styles can be applied to any ``<h1>``-``<h6>`` element by adding the appropriate ``.vui-heading-*`` class or by calling the ``#vui.Heading*`` Less mixin.
 
 .. role:: example
-    
+
 :example:`Example`
 
 .. raw:: html
 
-  <div class="vuiexamplebox">  
+  <div class="vuiexamplebox">
     <div class="vui-typography">
       <h1 style="border-bottom:none;" class="vui-heading-1">Heading Style 1</h1>
       <h2 style="border-bottom:none;" class="vui-heading-2">Heading Style 2</h2>
@@ -73,7 +73,7 @@ Four incremental heading styles can be applied to any ``<h1>``-``<h6>`` element 
 
   For additional information, see `Techniques for WCAG 2.0: Organizing a page using headings <http://www.w3.org/TR/WCAG-TECHS/G141.html>`_.
 
-Styling with Less 
+Styling with Less
 ==================
 To apply heading styles with Less, call the ``#vui-Heading1()`` - ``#vui-Heading4()`` mixin within the heading selector.  The selector level does not have to match the mixin level (for example, you can apply the ``#vui.Heading3()`` mixin for an ``h6`` selector).
 
@@ -97,7 +97,7 @@ To apply heading styles with Less, call the ``#vui-Heading1()`` - ``#vui-Heading
     #vui.Heading4();
   }
 
-Styling with CSS 
+Styling with CSS
 ==================
 To apply heading styles with plain CSS, add the appropriate ``.vui-heading-*`` class to any heading element.  The CSS class does not need to match the element level (for example, the ``.vui-heading-3`` class can be applied to a ``<h6>`` element.)
 
@@ -116,7 +116,7 @@ Emphasis
 Emphasis can be added to any text elements (for example, ``<p>`` and ``<span>``).
 
 .. role:: example
-    
+
 :example:`Example`
 
 .. raw:: html
@@ -128,7 +128,7 @@ Emphasis can be added to any text elements (for example, ``<p>`` and ``<span>``)
   </div>
   </div>
 
-Styling with Less 
+Styling with Less
 ==================
 To apply the emphasis style with Less, call the ``#vui.Typography.emphasis()`` mixin within the selector.
 
@@ -139,7 +139,7 @@ To apply the emphasis style with Less, call the ``#vui.Typography.emphasis()`` m
   }
 
 
-Styling with CSS 
+Styling with CSS
 ==================
 To apply the emphasis style with CSS, add the ``.vui-emphasis`` class to the text element.
 
@@ -155,7 +155,7 @@ Help
 The "help" style can be applied to any text elements (for example, ``<p>`` and ``<span>``).
 
 .. role:: example
-    
+
 :example:`Example`
 
 .. raw:: html
@@ -170,12 +170,12 @@ The "help" style can be applied to any text elements (for example, ``<p>`` and `
 
 .. admonition::  Accessibility
 
-  If the help information is included in a form, make sure it can be navigated to by a screen reader.  The help information can be associated to a form field by using the ``aria-describedby`` attribute. 
+  If the help information is included in a form, make sure it can be navigated to by a screen reader.  The help information can be associated to a form field by using the ``aria-describedby`` attribute.
 
   For more information, read `WebAIM's article on Advanced Form Labeling <http://webaim.org/techniques/forms/advanced#describedby>`_.
 
 
-Styling with Less 
+Styling with Less
 ==================
 To apply the help style with Less, call the ``#vui.Typography.help()`` mixin within the selector.
 
@@ -185,7 +185,7 @@ To apply the help style with Less, call the ``#vui.Typography.help()`` mixin wit
     #vui.Typography.help();
   }
 
-Styling with CSS 
+Styling with CSS
 ==================
 To apply the help style with CSS, add the ``.vui-help`` class to the text element.
 


### PR DESCRIPTION
I found the links to nom's search not super helpful. Often I wanted to look at the source for more details.

An alternative option would be to link to the npm package but I can't imagine wanting to go there vs.Github, and if things are going to transition to bower then thats moot anyway.
